### PR TITLE
Replace dbg! with debug!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ default-target = "x86_64-pc-windows-msvc"
 [dependencies]
 bitflags = "1.2.1"
 byteorder = "1.3.4"
+log = "0.4.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mslnk"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2018"
 documentation = "https://docs.rs/mslnk/"
 readme = "README.md"
@@ -14,6 +14,6 @@ repository = "https://github.com/dobefore/mslnk.git"
 default-target = "x86_64-pc-windows-msvc"
 
 [dependencies]
-bitflags = "1.2.1"
-byteorder = "1.3.4"
+bitflags = "1.3.2"
+byteorder = "1.4.3"
 log = "0.4.14"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 //! let sl = ShellLink::new(target).unwrap();
 //! sl.create_lnk(lnk).unwrap();
 //! ``
+use log::debug;
 use std::fs::File;
 use std::io::{prelude::*, BufWriter};
 use std::path::Path;
@@ -110,7 +111,7 @@ impl ShellLink {
     pub fn create_lnk<P: AsRef<std::path::Path>>(&self, path: P) -> std::io::Result<()> {
         let mut w = BufWriter::new(File::create(path)?);
 
-        dbg!("Writing header...");
+        debug!("Writing header...");
         let header_data: [u8; 0x4c] = self.shell_link_header.into();
         w.write_all(&header_data)?;
 
@@ -122,13 +123,13 @@ impl ShellLink {
         }
 
         if link_flags.contains(LinkFlags::HAS_LINK_INFO) {
-            dbg!("LinkInfo is marked as present. Writing.");
+            debug!("LinkInfo is marked as present. Writing.");
             let mut data: Vec<u8> = self.link_info.clone().unwrap().into();
             w.write_all(&mut data)?;
         }
 
         if link_flags.contains(LinkFlags::HAS_NAME) {
-            dbg!("Name is marked as present. Writing.");
+            debug!("Name is marked as present. Writing.");
             w.write_all(&stringdata::to_data(
                 self.name_string.as_ref().unwrap(),
                 link_flags,
@@ -136,7 +137,7 @@ impl ShellLink {
         }
 
         if link_flags.contains(LinkFlags::HAS_RELATIVE_PATH) {
-            dbg!("Relative path is marked as present. Writing.");
+            debug!("Relative path is marked as present. Writing.");
             w.write_all(&stringdata::to_data(
                 self.relative_path.as_ref().unwrap(),
                 link_flags,
@@ -144,7 +145,7 @@ impl ShellLink {
         }
 
         if link_flags.contains(LinkFlags::HAS_WORKING_DIR) {
-            dbg!("Working dir is marked as present. Writing.");
+            debug!("Working dir is marked as present. Writing.");
             w.write_all(&stringdata::to_data(
                 self.working_dir.as_ref().unwrap(),
                 link_flags,
@@ -152,7 +153,7 @@ impl ShellLink {
         }
 
         if link_flags.contains(LinkFlags::HAS_ARGUMENTS) {
-            dbg!("Arguments are marked as present. Writing.");
+            debug!("Arguments are marked as present. Writing.");
             w.write_all(&stringdata::to_data(
                 self.command_line_arguments.as_ref().unwrap(),
                 link_flags,
@@ -160,7 +161,7 @@ impl ShellLink {
         }
 
         if link_flags.contains(LinkFlags::HAS_ICON_LOCATION) {
-            dbg!("Icon Location is marked as present. Writing.");
+            debug!("Icon Location is marked as present. Writing.");
             w.write_all(&stringdata::to_data(
                 self.icon_location.as_ref().unwrap(),
                 link_flags,

--- a/src/stringdata.rs
+++ b/src/stringdata.rs
@@ -1,5 +1,6 @@
 use crate::LinkFlags;
 use byteorder::{ByteOrder, LE};
+use log::debug;
 
 pub fn parse_string(data: &[u8], flags: LinkFlags) -> (usize, String) {
     let result = if !flags.contains(LinkFlags::IS_UNICODE) {
@@ -23,7 +24,7 @@ pub fn parse_string(data: &[u8], flags: LinkFlags) -> (usize, String) {
         LE::read_u16_into(char_data, &mut u16_chars);
         (total_bytes, String::from_utf16_lossy(&u16_chars))
     };
-    dbg!("Parsed string: {:?}", &result);
+    debug!("Parsed string: {:?}", &result);
     result
 }
 


### PR DESCRIPTION
`!dbg` macro produces output even in release builds.
It is impossible for users of this library to suppress that output.
My quick fix proposal is to replace `dbg!` macro with `debug!` macro from `log` crate.